### PR TITLE
Init mongo

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,5 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint"],
   extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
-  rules: {
-    "@typescript-eslint/semi": "off"
-  }
+  rules: {}
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,12 +30,20 @@ services:
       - "27017:27017"
     volumes:
       - "mongo-data:/data/db"
+      # When this volume is present the image will initialize the database with
+      # the script inside init-mongo/ when container is started for the first
+      # time
+      - ./init-mongo:/docker-entrypoint-initdb.d
 
   mongodb-test:
     <<: *mongodb-base
+    ports:
+      - "27018:27017"
     # Using tmpfs runs this in memory to make the tests faster
     tmpfs:
       - /data/db
+    volumes:
+      - ./init-mongo:/docker-entrypoint-initdb.d
 
 volumes:
   mongo-data:

--- a/init-mongo/restore-mongo.sh
+++ b/init-mongo/restore-mongo.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+mongorestore \
+  --username "$DB_USER" \
+  --password "$DB_PASSWORD" \
+  --authenticationDatabase admin \
+  --archive=/docker-entrypoint-initdb.d/db.dump.archive.gz --gzip \
+  --gzip

--- a/src/bin/dump-mongo.sh
+++ b/src/bin/dump-mongo.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+docker-compose exec -T mongodb sh -c '
+  mongodump \
+    --archive \
+    --gzip \
+    --username "$DB_USER" \
+    --password "$DB_PASSWORD" \
+    --authenticationDatabase admin \
+    --db "$DB_NAME"
+' > ../../init-mongo/db.dump.archive.gz
+

--- a/src/services/listingSearchService.ts
+++ b/src/services/listingSearchService.ts
@@ -78,7 +78,6 @@ export const getResponseForPlaceId = async (ctx: GeocodeBoundaryContext) => {
   // Logic in the controller handles that for the sake of effeciency
   if (isListingAddressType(getAddressTypesFromParams(address_types))) return;
 
-  const pagination = getPaginationParams(ctx.query);
   const boundary = await Boundary.findOne({ placeId: place_id });
   if (!boundary) {
     const { geometry } = (
@@ -87,6 +86,7 @@ export const getResponseForPlaceId = async (ctx: GeocodeBoundaryContext) => {
     if (!geometry) return;
     return listingSearchGeocodeNoBoundaryView(geometry.viewport);
   }
+  const pagination = getPaginationParams(ctx.query);
   const results = await ctx.repositories.listing.findWithinBounds(
     boundary.geometry,
     ctx.query,
@@ -114,11 +114,11 @@ export const getResponseForBoundary = async (
   { place_id, geometry }: GeocodeResult,
   ctx: GeocodeBoundaryContext
 ) => {
-  const pagination = getPaginationParams(ctx.query);
   const boundary = await Boundary.findOne({ placeId: place_id });
   if (!boundary) {
     return listingSearchGeocodeNoBoundaryView(geometry.viewport);
   }
+  const pagination = getPaginationParams(ctx.query);
   const results = await ctx.repositories.listing.findWithinBounds(
     boundary.geometry,
     ctx.query,

--- a/src/services/listingSearchService.ts
+++ b/src/services/listingSearchService.ts
@@ -8,7 +8,6 @@ import { type Context } from "koa";
 import { getPaginationParams } from "../lib";
 import { type GeocodeBoundaryContext } from "../controllers/listingSearchController";
 import type { IBoundary } from "../models/BoundaryModel";
-import Boundary from "../models/BoundaryModel";
 import listingSearchBoundaryView from "../views/listingSearchBoundaryView";
 import listingSearchGeocodeNoBoundaryView from "../views/listingSearchGeocodeNoBoundaryView";
 import type { BoundarySearchQueryParams } from "../zod_schemas/boundarySearchRequestSchema";
@@ -78,7 +77,7 @@ export const getResponseForPlaceId = async (ctx: GeocodeBoundaryContext) => {
   // Logic in the controller handles that for the sake of effeciency
   if (isListingAddressType(getAddressTypesFromParams(address_types))) return;
 
-  const boundary = await Boundary.findOne({ placeId: place_id });
+  const boundary = await ctx.repositories.boundary.findByPlaceId(place_id);
   if (!boundary) {
     const { geometry } = (
       await ctx.geocodeService.getPlaceDetails({ place_id })
@@ -114,7 +113,7 @@ export const getResponseForBoundary = async (
   { place_id, geometry }: GeocodeResult,
   ctx: GeocodeBoundaryContext
 ) => {
-  const boundary = await Boundary.findOne({ placeId: place_id });
+  const boundary = await ctx.repositories.boundary.findByPlaceId(place_id);
   if (!boundary) {
     return listingSearchGeocodeNoBoundaryView(geometry.viewport);
   }

--- a/src/test/routes/listingRouter.test.ts
+++ b/src/test/routes/listingRouter.test.ts
@@ -1,51 +1,30 @@
-import type { HydratedDocument } from "mongoose";
 import request from "supertest";
 import { buildApp } from "../../app";
-import type { ListingData } from "../../lib/random_data";
-import Listing, { IListing } from "../../models/ListingModel";
+import Listing from "../../models/ListingModel";
 
 const app = buildApp();
 
-const listingData: ListingData = {
-  listPrice: 700000,
-  listedDate: new Date(),
-  address: {
-    line1: "123 Test St",
-    city: "Test",
-    state: "WA",
-    zip: "12345"
-  },
-  geometry: {
-    type: "Point",
-    coordinates: [-122.3507218, 47.6610594]
-  },
-  beds: 2,
-  baths: 1,
-  sqft: 2345,
-  lotSize: 234312,
-  yearBuilt: 1984,
-  neighborhood: "Test Hills",
-  propertyType: "single-family",
-  status: "active"
-};
-
 describe("listingRouter", () => {
   describe("GET /listing/:id", () => {
-    let listing: HydratedDocument<IListing>;
-
-    beforeAll(async () => {
-      listing = await Listing.create(listingData);
-    });
-
-    afterAll(async () => {
-      await Listing.deleteOne({ _id: listing._id });
+    it("validates the listing ID param type", async () => {
+      const res = await request(app.callback()).get("/listing/invalid_type");
+      expect(res.status).toBe(400);
     });
 
     it("returns a listing", async () => {
+      const listing = await Listing.findOne().lean();
+      if (!listing) throw new Error("No listings found in test database");
       const res = await request(app.callback()).get(`/listing/${listing._id}`);
       expect(res.status).toBe(200);
-      expect(res.body.listPrice).toBe(700000);
-      expect(res.body._id).toBe(listing._id.toString());
+      expect(res.body._id).toBe(listing._id);
+    });
+
+    it("returns a not found status when a listing with the given ID does not exist", async () => {
+      const nonExistentId = new Listing()._id;
+      const res = await request(app.callback()).get(
+        `/listing/${nonExistentId}`
+      );
+      expect(res.status).toBe(404);
     });
   });
 });

--- a/src/test/routes/listingSearchRouter.test.ts
+++ b/src/test/routes/listingSearchRouter.test.ts
@@ -1,56 +1,17 @@
 import request from "supertest";
 import { buildApp } from "../../app";
-import type { ListingData } from "../../lib/random_data";
 import Boundary from "../../models/BoundaryModel";
-import Listing from "../../models/ListingModel";
 import type { ListingSearchResponse } from "../../types/listing_search_response_types";
 
-const ViewportBoundsFremont = {
+const FremontViewportBounds = {
   bounds_north: 47.69011227856514,
   bounds_east: -122.32789118536581,
   bounds_south: 47.62356960805306,
   bounds_west: -122.38144953497519
 };
 
-const listingData: ListingData = {
-  placeId: "ChIJx-PUpKcVkFQRuyjbZcMero4",
-  listPrice: 700000,
-  listedDate: new Date(),
-  address: {
-    line1: "325 West Bertona Street",
-    city: "Seattle",
-    state: "WA",
-    zip: "981119"
-  },
-  geometry: {
-    type: "Point",
-    coordinates: [-122.36202928170573, 47.650447901587384]
-  },
-  beds: 2,
-  baths: 1,
-  sqft: 2345,
-  lotSize: 234312,
-  yearBuilt: 1984,
-  neighborhood: "Fremont",
-  propertyType: "single-family",
-  status: "active"
-};
-
-const outsideBoundsListingData: ListingData = {
-  ...listingData,
-  placeId: "ChIJgSaVY10UkFQRatRdh9A5h-k",
-  address: {
-    line1: "5507 Latona Avenue Northeast",
-    city: "Seattle",
-    state: "WA",
-    zip: "98105"
-  },
-  geometry: {
-    type: "Point",
-    coordinates: [-122.3263041928006, 47.66905938924199]
-  },
-  neighborhood: "Wallingford"
-};
+const InsideBoundsPlaceId = "ChIJx-PUpKcVkFQRuyjbZcMero4";
+const OutsideBoundsPlaceId = "ChIJgSaVY10UkFQRatRdh9A5h-k";
 
 const app = buildApp();
 
@@ -58,8 +19,9 @@ describe("listingSearchRouter", () => {
   describe("GET /listing/search/boundary/:id", () => {
     it("returns a successful status when a boundary with the given ID exists", async () => {
       const boundary = await Boundary.findOne().lean();
+      if (!boundary) throw new Error("No boundaries found in test database");
       const res = await request(app.callback()).get(
-        `/listing/search/boundary/${boundary?._id}`
+        `/listing/search/boundary/${boundary._id}`
       );
       expect(res.status).toBe(200);
     });
@@ -72,7 +34,7 @@ describe("listingSearchRouter", () => {
     });
 
     it("returns a not found status when a boundary with the given ID does not exist", async () => {
-      const nonExistentId = new Boundary()._id.toString();
+      const nonExistentId = new Boundary()._id;
       const res = await request(app.callback()).get(
         `/listing/search/boundary/${nonExistentId}`
       );
@@ -82,23 +44,20 @@ describe("listingSearchRouter", () => {
 
   describe("GET /listing/search/bounds", () => {
     it("validates that all bounds params are present", async () => {
-      const res = await request(app.callback()).get(`/listing/search/bounds`);
+      const res = await request(app.callback())
+        .get(`/listing/search/bounds`)
+        .query({ bounds_north: 47.69011227856514 });
       expect(res.status).toBe(400);
     });
 
     it("Only returns listings that are inside the bounds", async () => {
-      const listingInsideBounds = await Listing.create(listingData);
-      const listingOutsideBounds = await Listing.create(
-        outsideBoundsListingData
-      );
-
       const res = await request(app.callback())
         .get("/listing/search/bounds")
-        .query(ViewportBoundsFremont);
+        .query(FremontViewportBounds);
       const data: ListingSearchResponse = res.body;
-      const foundListingIds = data.listings.map((l) => l.placeId);
-      expect(foundListingIds).toContain(listingInsideBounds.placeId);
-      expect(foundListingIds).not.toContain(listingOutsideBounds.placeId);
+      const foundListingPlaceIds = data.listings.map((l) => l.placeId);
+      expect(foundListingPlaceIds).toContain(InsideBoundsPlaceId);
+      expect(foundListingPlaceIds).not.toContain(OutsideBoundsPlaceId);
     });
   });
 });

--- a/src/test/setupFile.ts
+++ b/src/test/setupFile.ts
@@ -1,23 +1,10 @@
 import mongoose from "mongoose";
-import path from "path";
-import { createBoundariesFromFile } from "../lib/seed_data";
 import { MongoDbUrl } from "../config";
-
-const BoundaryFilePath = path.join(
-  __dirname,
-  "..",
-  "data",
-  "seed_data",
-  "test",
-  "test_boundaries.json"
-);
 
 beforeAll(async () => {
   await mongoose.connect(MongoDbUrl);
-  await createBoundariesFromFile(BoundaryFilePath);
 });
 
 afterAll(async () => {
-  await mongoose.connection.dropDatabase();
   await mongoose.connection.close();
 });


### PR DESCRIPTION
Added a script to seed the dev and test mongodb containers with data when they're first started. This way there doesn't need to be an extra step involved for setting up the project. It also makes the tests simpler because we can just use the data that is in the test container rather than having to re-create it inside the tests each time they run.