### PR TITLE
Parse array params

### DIFF
--- a/src/models/ListingModel.ts
+++ b/src/models/ListingModel.ts
@@ -17,10 +17,7 @@ export const PropertyStatuses = ["active", "pending", "sold"] as const;
 
 export const RentalPropertyStatuses = ["active", "rented"] as const;
 
-export const AllPropertyStatuses = [
-  ...PropertyStatuses,
-  ...RentalPropertyStatuses
-];
+export const AllPropertyStatuses = [...PropertyStatuses, "rented"] as const;
 
 export type PropertyType = (typeof PropertyTypes)[number];
 

--- a/src/queries/listingQueries.ts
+++ b/src/queries/listingQueries.ts
@@ -110,7 +110,7 @@ export const buildFilterQueries = (
   if (q.property_type) {
     filters.push({
       propertyType: {
-        $in: q.property_type.split(",")
+        $in: q.property_type
       }
     });
   }

--- a/src/queries/listingQueries.ts
+++ b/src/queries/listingQueries.ts
@@ -105,7 +105,7 @@ export const buildFilterQueries = (
 ): FilterQuery<IListing>[] => {
   const filters = [];
 
-  filters.push({ status: q.status ? { $in: q.status.split(",") } : "active" });
+  filters.push({ status: q.status ? { $in: q.status } : "active" });
 
   if (q.property_type) {
     filters.push({

--- a/src/test/routes/filters.test.ts
+++ b/src/test/routes/filters.test.ts
@@ -128,6 +128,16 @@ describe("filters", () => {
       });
     });
 
+    it("validates the status type", async () => {
+      const res = await request(app.callback())
+        .get("/listing/search/bounds")
+        .query({
+          ...FremontViewportBounds,
+          status: "sold,invalid_type"
+        });
+      expect(res.status).toBe(400);
+    });
+
     describe("when the status param is included", () => {
       it("only returns the statuses that are requested", async () => {
         const requestedStatuses = ["pending", "sold"];

--- a/src/test/routes/filters.test.ts
+++ b/src/test/routes/filters.test.ts
@@ -128,12 +128,12 @@ describe("filters", () => {
       });
     });
 
-    it("validates the status type", async () => {
+    it("validates the values of status", async () => {
       const res = await request(app.callback())
         .get("/listing/search/bounds")
         .query({
           ...FremontViewportBounds,
-          status: "sold,invalid_type"
+          status: "sold,invalid_status"
         });
       expect(res.status).toBe(400);
     });
@@ -188,6 +188,16 @@ describe("filters", () => {
       await ListingModel.deleteMany({
         _id: { $in: listingIds }
       });
+    });
+
+    it("validates the values of property_type", async () => {
+      const res = await request(app.callback())
+        .get("/listing/search/bounds")
+        .query({
+          ...FremontViewportBounds,
+          property_type: "condo,invalid_type"
+        });
+      expect(res.status).toBe(400);
     });
 
     describe("when the property_type param is included", () => {

--- a/src/zod_schemas/listingSearchParamsSchema.ts
+++ b/src/zod_schemas/listingSearchParamsSchema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { booleanEnum } from ".";
+import { AllPropertyStatuses } from '../models/ListingModel';
 
 export const sortTypeSchema = z.enum([
   "listedDate",
@@ -40,7 +41,10 @@ export const listingFilterParamsSchema = z
     sort_direction: sortDirectionSchema,
     sold_days: z.coerce.number(),
     property_type: z.string(),
-    status: z.string(),
+    status: z
+      .string()
+      .transform((s) => s.split(",").map((s) => s.trim()))
+      .pipe(z.array(z.enum(AllPropertyStatuses))),
     waterfront: booleanEnum,
     view: booleanEnum,
     fireplace: booleanEnum,

--- a/src/zod_schemas/listingSearchParamsSchema.ts
+++ b/src/zod_schemas/listingSearchParamsSchema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { booleanEnum } from ".";
-import { AllPropertyStatuses } from '../models/ListingModel';
+import { AllPropertyStatuses, PropertyTypes } from "../models/ListingModel";
 
 export const sortTypeSchema = z.enum([
   "listedDate",
@@ -40,7 +40,10 @@ export const listingFilterParamsSchema = z
     sort_by: sortTypeSchema,
     sort_direction: sortDirectionSchema,
     sold_days: z.coerce.number(),
-    property_type: z.string(),
+    property_type: z
+      .string()
+      .transform((s) => s.split(",").map((s) => s.trim()))
+      .pipe(z.array(z.enum(PropertyTypes))),
     status: z
       .string()
       .transform((s) => s.split(",").map((s) => s.trim()))

--- a/src/zod_schemas/listingsRequestSchema.ts
+++ b/src/zod_schemas/listingsRequestSchema.ts
@@ -4,8 +4,7 @@ import { ValidObjectIdRegex } from ".";
 export const listingsParams = z.object({
   ids: z
     .string()
-    .trim()
-    .transform((ids) => ids.split(","))
+    .transform((ids) => ids.split(",").map((s) => s.trim()))
     .refine((ids) => ids.every((id) => ValidObjectIdRegex.test(id)), {
       message: "Every ID should be a valid ObjectId"
     })


### PR DESCRIPTION
We're now parsing the status and property_type params string into an array in the Zod schema rather than in the function that builds the query. We're also validating the values in the array to make sure they are values that actually exist in the db.